### PR TITLE
Update DefaultRemovePatterns.json

### DIFF
--- a/Generic/LinkUtilities/Resources/DefaultRemovePatterns.json
+++ b/Generic/LinkUtilities/Resources/DefaultRemovePatterns.json
@@ -6,6 +6,18 @@
         "partialMatch": false
     },       
     {
+        "linkName": "PCGamingWiki appdata",
+        "urlPattern": "https://pcgamingwiki.com/api/appid.php?appid=*",
+        "namePattern": "",
+        "partialMatch": true
+    },
+    {
+        "linkName": "Facebook",
+        "urlPattern": "*facebook.com*",
+        "namePattern": "*Facebook*",
+        "partialMatch": true
+    },     
+    {
         "linkName": "Facebook",
         "urlPattern": "*facebook.com*",
         "namePattern": "*Facebook*",

--- a/Generic/LinkUtilities/Resources/DefaultRemovePatterns.json
+++ b/Generic/LinkUtilities/Resources/DefaultRemovePatterns.json
@@ -18,12 +18,6 @@
         "partialMatch": true
     },     
     {
-        "linkName": "Facebook",
-        "urlPattern": "*facebook.com*",
-        "namePattern": "*Facebook*",
-        "partialMatch": true
-    },
-    {
         "linkName": "Instagram",
         "urlPattern": "*instagram.com*",
         "namePattern": "*Instagram*",


### PR DESCRIPTION
The PCGamingWiki links provided by Steam are often useless because they don't have an associated page. I added a link pattern to check for PCGamingWiki links with 'appid.'